### PR TITLE
renderer: delete useless ifdefs

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -33,9 +33,7 @@
 #include "pass/SurfacePassElement.hpp"
 #include "debug/Log.hpp"
 #include "../protocols/ColorManagement.hpp"
-#if AQUAMARINE_VERSION_NUMBER > 702 // >0.7.2
 #include "../protocols/types/ContentType.hpp"
-#endif
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 using namespace Hyprutils::Utils;
@@ -1495,13 +1493,11 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
     }
 
-#if AQUAMARINE_VERSION_NUMBER > 702 // >0.7.2
     if (pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_bHasFullscreenWindow && pMonitor->activeWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN) {
         const auto WINDOW = pMonitor->activeWorkspace->getFullscreenWindow();
         pMonitor->output->state->setContentType(NContentType::toDRM(WINDOW->getContentType()));
     } else
         pMonitor->output->state->setContentType(NContentType::toDRM(CONTENT_TYPE_NONE));
-#endif
 
     if (pMonitor->ctmUpdated) {
         pMonitor->ctmUpdated = false;


### PR DESCRIPTION
Hyprland for now requires aquamarine =>0.8.0 anyway

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
PR title speaks by itself?

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I didn't remove def from `macros.hpp`, but if ya wanna to remove it, then i'll also do it.

#### Is it ready for merging, or does it need work?
Should be ready?

